### PR TITLE
fix(root): layout structure

### DIFF
--- a/src/components/Layout/LayoutSideNav.tsx
+++ b/src/components/Layout/LayoutSideNav.tsx
@@ -6,7 +6,7 @@ export type LayoutSideNavProps = LayoutNavProps
 export const LayoutSideNav = ({ className, ...others }: LayoutSideNavProps) => {
   return (
     <LayoutNav
-      className={cx(className, 'sticky top-[64px] hidden w-sz-256 min-w-sz-256 md:block')}
+      className={cx(className, 'sticky hidden w-sz-256 min-w-sz-256 md:block')}
       {...others}
     />
   )

--- a/src/pages/docs/[slug]/index.tsx
+++ b/src/pages/docs/[slug]/index.tsx
@@ -17,10 +17,9 @@ const DocDetailPage = ({ doc }: DocDetailPageProps) => {
 
       <LayoutHeader />
 
-      <LayoutContainer className="flex gap-2xl" asChild>
+      <LayoutContainer className="flex gap-2xl">
+        <LayoutSideNav />
         <main>
-          <LayoutSideNav />
-
           <div className="min-w-0 flex-1">
             <MDXComponent code={doc.body.code} globals={{ examples: doc.examples }} />
           </div>


### PR DESCRIPTION
The basic idea of the `<main>` element is that the content within it is considered unique to the document (which lends itself to the entire concept of individual documents within a site).

Since site-wide navigation is supposed to exist across the whole site, it should exist outside of the `<main>` element.