### PR TITLE
fix(modeIconButton): fix initial icon to the corresponding one

### DIFF
--- a/src/components/Shared/ModeIconButton.tsx
+++ b/src/components/Shared/ModeIconButton.tsx
@@ -12,9 +12,7 @@ export const ModeIconButton = (props: ModeIconButtonProps) => {
 
   useEffect(() => {
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-    if (prefersDark) {
-      setTheme(prefersDark ? 'dark' : 'light')
-    }
+    setTheme(prefersDark ? 'dark' : 'light')
     setIsMounted(true)
   }, [])
 

--- a/src/components/Shared/ModeIconButton.tsx
+++ b/src/components/Shared/ModeIconButton.tsx
@@ -11,6 +11,10 @@ export const ModeIconButton = (props: ModeIconButtonProps) => {
   const { theme, setTheme } = useTheme()
 
   useEffect(() => {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    if (prefersDark) {
+      setTheme(prefersDark ? 'dark' : 'light')
+    }
     setIsMounted(true)
   }, [])
 


### PR DESCRIPTION
when initializing in light mode you have to click twice to change to dark mode.

now the initial button state is aligned with the initial color schema